### PR TITLE
setting: swagger 설정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("tools.jackson.module:jackson-module-kotlin")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0")
     developmentOnly("org.springframework.boot:spring-boot-docker-compose")
     runtimeOnly("org.postgresql:postgresql")
     testRuntimeOnly("com.h2database:h2")

--- a/src/main/kotlin/kr/co/lokit/api/config/docs/OpenApiConfig.kt
+++ b/src/main/kotlin/kr/co/lokit/api/config/docs/OpenApiConfig.kt
@@ -1,0 +1,38 @@
+package kr.co.lokit.api.config.docs
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.servers.Server
+import org.springdoc.core.models.GroupedOpenApi
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiConfig {
+    @Value("\${server.servlet.context-path:/}")
+    private lateinit var contextPath: String
+
+    @Bean
+    fun openApi(): OpenAPI =
+        OpenAPI()
+            .info(
+                Info()
+                    .title("Lokit API")
+                    .version("1.0.0")
+                    .description("Lokit API 문서"),
+            )
+            .servers(
+                listOf(
+                    Server().url(contextPath).description("API Server"),
+                ),
+            )
+
+    @Bean
+    fun apiGroup(): GroupedOpenApi =
+        GroupedOpenApi
+            .builder()
+            .group("api")
+            .packagesToScan("kr.co.lokit.api")
+            .build()
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -32,3 +32,14 @@ management:
     endpoint:
         health:
             show-details: when-authorized
+
+springdoc:
+    api-docs:
+        enabled: true
+        path: /docs
+    swagger-ui:
+        enabled: true
+        path: /swagger
+        display-request-duration: true
+    default-consumes-media-type: application/json
+    default-produces-media-type: application/json

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -11,6 +11,8 @@ spring:
             hibernate:
                 dialect: org.hibernate.dialect.PostgreSQLDialect
                 format_sql: true
+                show_sql: true
+                use_sql_comments: true
             jdbc:
                 time_zone: Asia/Seoul
         open-in-view: false
@@ -22,6 +24,8 @@ spring:
 
 logging:
     level:
+        org.hibernate.orm.jdbc.bind: trace
+        root: INFO
         kr.co.lokit.api: DEBUG
 
 management:
@@ -30,3 +34,14 @@ management:
             exposure:
                 include: "health"
             base-path: /actuator
+
+springdoc:
+    api-docs:
+        enabled: true
+        path: /docs
+    swagger-ui:
+        enabled: true
+        path: /swagger
+        display-request-duration: true
+    default-consumes-media-type: application/json
+    default-produces-media-type: application/json


### PR DESCRIPTION
## 수정 이유
- API-Docs 를 통한 협업을 위해 진행했습니다.
- #4 

## 추가/수정한 기능
- Swagger 설정을 추가했습니다.
- 몇몇 누락된 사소한 설정들을 추가했습니다. (로그레벨, 쿼리로그 관련)

## 특이사항
- 서버 기동 이후 다음 링크에서 API 문서 확인 가능합니다. (공통 응답 규격 작업에서 버저닝 관련 수정이 있기에 함께 반영 이후에 접근 가능합니다.)
  - {ip}:{port}/api/swagger

- 아래는 테스트용 API를 만들어둔 후 접속한 화면 결과입니다:
<img width="1669" height="947" alt="image" src="https://github.com/user-attachments/assets/2d92f09f-914d-43b1-9c2c-c45508fa9244" />

## check list

- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?
