### PR TITLE
setting: SSH 포트 보안그룹 추가/제거 자동화를 cd 플로우에 추가

### DIFF
--- a/.github/workflows/dev-cd.yaml
+++ b/.github/workflows/dev-cd.yaml
@@ -24,6 +24,19 @@ jobs:
                     aws-secret-access-key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
                     aws-region: ${{ env.AWS_REGION }}
 
+            -   name: Get Runner IP
+                id: ip
+                run: echo "runner_ip=$(curl -s https://checkip.amazonaws.com)" >> $GITHUB_OUTPUT
+
+            -   name: Add Runner IP to Security Group
+                run: |
+                    aws ec2 authorize-security-group-ingress \
+                        --group-id ${{ secrets.DEV_SECURITY_GROUP_ID }} \
+                        --protocol tcp \
+                        --port 22 \
+                        --cidr ${{ steps.ip.outputs.runner_ip }}/32 \
+                        --region ${{ env.AWS_REGION }}
+
             -   name: Login to Amazon ECR
                 id: login-ecr
                 uses: aws-actions/amazon-ecr-login@v2
@@ -97,3 +110,13 @@ jobs:
                         docker logs $CONTAINER_NAME --tail 30
 
                         docker image prune -af --filter "until=24h"
+
+            -   name: Remove Runner IP from Security Group
+                if: always()
+                run: |
+                    aws ec2 revoke-security-group-ingress \
+                        --group-id ${{ secrets.DEV_SECURITY_GROUP_ID }} \
+                        --protocol tcp \
+                        --port 22 \
+                        --cidr ${{ steps.ip.outputs.runner_ip }}/32 \
+                        --region ${{ env.AWS_REGION }} || true


### PR DESCRIPTION
## 수정 이유
- GitHub Actions dev-cd.yaml 에 보안그룹 ssh 규칙 추가 -> 작업 ->  제거 자동화 필요
- #8 

## 추가/수정한 기능
- 개발 서버 보안그룹 규칙 자동화

## 특이사항
- 없습니다.

## check list

- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?
