### PR TITLE
로그아웃 api, 커플 첫 만남 수정 api 구현

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -341,8 +341,8 @@ jobs:
                             --name $CONTAINER_NAME \
                             --restart unless-stopped \
                             --network lokit-net \
-                            --memory="768m" \
-                            --memory-swap="1024m" \
+                            --memory="1024m" \
+                            --memory-swap="1536m" \
                             -p 8080:8080 \
                             -e SPRING_PROFILES_ACTIVE=dev \
                             -e DISCORD_LIFECYCLE_ENABLED=true \
@@ -358,6 +358,7 @@ jobs:
 
                         docker rm -f caddy
                         docker compose -f compose.yaml up -d
+                        docker update --memory="192m" --memory-swap="256m" caddy || true
 
                         docker ps --filter "name=$CONTAINER_NAME" --format "{{.Status}}"
 

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -339,8 +339,8 @@ jobs:
                             --name $CONTAINER_NAME \
                             --restart unless-stopped \
                             --network lokit-net \
-                            --memory="768m" \
-                            --memory-swap="1024m" \
+                            --memory="1024m" \
+                            --memory-swap="1536m" \
                             -p 8080:8080 \
                             -e SPRING_PROFILES_ACTIVE=prod \
                             -e DISCORD_LIFECYCLE_ENABLED=true \
@@ -356,6 +356,7 @@ jobs:
 
                         docker rm -f caddy
                         docker compose -f compose.yaml up -d
+                        docker update --memory="192m" --memory-swap="256m" caddy || true
 
                         docker ps --filter "name=$CONTAINER_NAME" --format "{{.Status}}"
 

--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -19,8 +19,8 @@ USER spring
 EXPOSE 8080
 
 ENV JAVA_OPTS="-XX:+UseContainerSupport \
-    -XX:MaxRAMPercentage=55 \
-    -XX:InitialRAMPercentage=25 \
+    -XX:MaxRAMPercentage=45 \
+    -XX:InitialRAMPercentage=20 \
     -Xss512k \
     -XX:+TieredCompilation \
     -XX:TieredStopAtLevel=1 \

--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -19,7 +19,9 @@ USER spring
 EXPOSE 8080
 
 ENV JAVA_OPTS="-XX:+UseContainerSupport \
-    -XX:MaxRAMPercentage=65 \
+    -XX:MaxRAMPercentage=55 \
+    -XX:InitialRAMPercentage=25 \
+    -Xss512k \
     -XX:+TieredCompilation \
     -XX:TieredStopAtLevel=1 \
     -XX:+ExitOnOutOfMemoryError \

--- a/src/main/kotlin/kr/co/lokit/api/common/constants/CoupleCookieStatus.kt
+++ b/src/main/kotlin/kr/co/lokit/api/common/constants/CoupleCookieStatus.kt
@@ -5,4 +5,5 @@ enum class CoupleCookieStatus {
     COUPLED,
     DISCONNECTED_BY_ME,
     DISCONNECTED_BY_PARTNER,
+    DISCONNECTED_EXPIRED,
 }

--- a/src/main/kotlin/kr/co/lokit/api/config/cache/CacheConfig.kt
+++ b/src/main/kotlin/kr/co/lokit/api/config/cache/CacheConfig.kt
@@ -22,7 +22,7 @@ class CacheConfig {
                     Caffeine
                         .newBuilder()
                         .expireAfterWrite(3, TimeUnit.MINUTES)
-                        .maximumSize(100)
+                        .maximumSize(80)
                         .build(),
                 ),
                 CaffeineCache(
@@ -30,7 +30,7 @@ class CacheConfig {
                     Caffeine
                         .newBuilder()
                         .expireAfterWrite(3, TimeUnit.MINUTES)
-                        .maximumSize(50)
+                        .maximumSize(30)
                         .build(),
                 ),
                 CaffeineCache(
@@ -38,7 +38,7 @@ class CacheConfig {
                     Caffeine
                         .newBuilder()
                         .expireAfterWrite(5, TimeUnit.MINUTES)
-                        .maximumSize(100)
+                        .maximumSize(80)
                         .build(),
                 ),
                 CaffeineCache(
@@ -46,7 +46,7 @@ class CacheConfig {
                     Caffeine
                         .newBuilder()
                         .expireAfterWrite(5, TimeUnit.MINUTES)
-                        .maximumSize(300)
+                        .maximumSize(180)
                         .build(),
                 ),
                 CaffeineCache(
@@ -54,7 +54,7 @@ class CacheConfig {
                     Caffeine
                         .newBuilder()
                         .expireAfterWrite(5, TimeUnit.MINUTES)
-                        .maximumSize(100)
+                        .maximumSize(80)
                         .build(),
                 ),
                 CaffeineCache(
@@ -62,7 +62,7 @@ class CacheConfig {
                     Caffeine
                         .newBuilder()
                         .expireAfterWrite(10, TimeUnit.MINUTES)
-                        .maximumSize(200)
+                        .maximumSize(120)
                         .build(),
                 ),
                 CaffeineCache(
@@ -70,7 +70,7 @@ class CacheConfig {
                     Caffeine
                         .newBuilder()
                         .expireAfterWrite(10, TimeUnit.MINUTES)
-                        .maximumSize(200)
+                        .maximumSize(120)
                         .build(),
                 ),
                 CaffeineCache(
@@ -78,7 +78,7 @@ class CacheConfig {
                     Caffeine
                         .newBuilder()
                         .expireAfterWrite(3, TimeUnit.MINUTES)
-                        .maximumSize(200)
+                        .maximumSize(120)
                         .build(),
                 ),
                 CaffeineCache(
@@ -86,7 +86,7 @@ class CacheConfig {
                     Caffeine
                         .newBuilder()
                         .expireAfterWrite(10, TimeUnit.MINUTES)
-                        .maximumSize(400)
+                        .maximumSize(250)
                         .build(),
                 ),
                 CaffeineCache(
@@ -94,7 +94,7 @@ class CacheConfig {
                     Caffeine
                         .newBuilder()
                         .expireAfterWrite(10, TimeUnit.MINUTES)
-                        .maximumSize(400)
+                        .maximumSize(100)
                         .build(),
                 ),
                 CaffeineCache(
@@ -102,7 +102,7 @@ class CacheConfig {
                     Caffeine
                         .newBuilder()
                         .expireAfterWrite(3, TimeUnit.MINUTES)
-                        .maximumSize(100)
+                        .maximumSize(80)
                         .build(),
                 ),
             ),

--- a/src/main/kotlin/kr/co/lokit/api/config/web/CookieGenerator.kt
+++ b/src/main/kotlin/kr/co/lokit/api/config/web/CookieGenerator.kt
@@ -33,6 +33,9 @@ class CookieGenerator(
         value: CoupleCookieStatus,
     ): ResponseCookie = createCookie(request, "coupleStatus", value.name, refreshTokenExpiration, httpOnly = false)
 
+    fun clearCoupleStatusCookie(request: HttpServletRequest): ResponseCookie =
+        createCookie(request, "coupleStatus", "", 0, httpOnly = false)
+
     fun createCookie(
         request: HttpServletRequest,
         name: String,

--- a/src/main/kotlin/kr/co/lokit/api/config/web/CookieGenerator.kt
+++ b/src/main/kotlin/kr/co/lokit/api/config/web/CookieGenerator.kt
@@ -31,7 +31,7 @@ class CookieGenerator(
     fun createCoupleStatusCookie(
         request: HttpServletRequest,
         value: CoupleCookieStatus,
-    ): ResponseCookie = createCookie(request, "coupleStatus", value.name, refreshTokenExpiration)
+    ): ResponseCookie = createCookie(request, "coupleStatus", value.name, refreshTokenExpiration, httpOnly = false)
 
     fun clearCoupleStatusCookie(request: HttpServletRequest): ResponseCookie =
         createCookie(request, "coupleStatus", "", 0, httpOnly = false)
@@ -41,7 +41,7 @@ class CookieGenerator(
         name: String,
         value: String,
         maxAgeMillis: Long,
-        httpOnly: Boolean = false,
+        httpOnly: Boolean = true,
     ): ResponseCookie {
         val serverName = request.serverName
         val isLocal = isLocalhost(serverName)

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCommandService.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCommandService.kt
@@ -1,15 +1,18 @@
 package kr.co.lokit.api.domain.couple.application
 
 import kr.co.lokit.api.common.annotation.OptimisticRetry
+import kr.co.lokit.api.common.exception.BusinessException
 import kr.co.lokit.api.config.cache.CacheNames
 import kr.co.lokit.api.domain.couple.application.port.CoupleRepositoryPort
 import kr.co.lokit.api.domain.couple.application.port.`in`.CreateCoupleUseCase
 import kr.co.lokit.api.domain.couple.domain.Couple
 import kr.co.lokit.api.domain.couple.domain.CoupleProfileImage
 import kr.co.lokit.api.domain.user.application.port.UserRepositoryPort
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.CachePut
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 
 @Service
 class CoupleCommandService(
@@ -34,4 +37,13 @@ class CoupleCommandService(
             }
             created
         }
+
+    @Transactional
+    @CacheEvict(cacheNames = [CacheNames.USER_COUPLE], key = "#userId")
+    fun updateFirstMetDate(userId: Long, firstMetDate: LocalDate) {
+        val couple =
+            coupleRepository.findByUserId(userId)
+                ?: throw BusinessException.CoupleNotFoundException()
+        coupleRepository.updateFirstMetDate(couple.id, firstMetDate)
+    }
 }

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCommandService.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCommandService.kt
@@ -3,12 +3,13 @@ package kr.co.lokit.api.domain.couple.application
 import kr.co.lokit.api.common.annotation.OptimisticRetry
 import kr.co.lokit.api.common.exception.BusinessException
 import kr.co.lokit.api.config.cache.CacheNames
+import kr.co.lokit.api.config.cache.evictUserCoupleCache
 import kr.co.lokit.api.domain.couple.application.port.CoupleRepositoryPort
 import kr.co.lokit.api.domain.couple.application.port.`in`.CreateCoupleUseCase
 import kr.co.lokit.api.domain.couple.domain.Couple
 import kr.co.lokit.api.domain.couple.domain.CoupleProfileImage
 import kr.co.lokit.api.domain.user.application.port.UserRepositoryPort
-import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.CachePut
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -19,6 +20,7 @@ class CoupleCommandService(
     private val coupleRepository: CoupleRepositoryPort,
     private val userRepository: UserRepositoryPort,
     private val coupleProfileImageUrlResolver: CoupleProfileImageUrlResolver,
+    private val cacheManager: CacheManager,
 ) : CreateCoupleUseCase {
     @OptimisticRetry
     @Transactional
@@ -39,11 +41,11 @@ class CoupleCommandService(
         }
 
     @Transactional
-    @CacheEvict(cacheNames = [CacheNames.USER_COUPLE], key = "#userId")
     fun updateFirstMetDate(userId: Long, firstMetDate: LocalDate) {
         val couple =
             coupleRepository.findByUserId(userId)
                 ?: throw BusinessException.CoupleNotFoundException()
         coupleRepository.updateFirstMetDate(couple.id, firstMetDate)
+        cacheManager.evictUserCoupleCache(*couple.userIds.toLongArray())
     }
 }

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCookieStatusResolver.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCookieStatusResolver.kt
@@ -33,9 +33,7 @@ class CoupleCookieStatusResolver(
         couple: Couple,
         userId: Long,
     ): CoupleCookieStatus {
-        if (couple.status == CoupleStatus.EXPIRED || couple.isReconnectWindowExpired() ||
-            !couple.hasRemainingMemberForReconnect()
-        ) {
+        if (couple.status == CoupleStatus.EXPIRED || couple.isReconnectWindowExpired()) {
             return CoupleCookieStatus.DISCONNECTED_EXPIRED
         }
 

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCookieStatusResolver.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCookieStatusResolver.kt
@@ -40,13 +40,6 @@ class CoupleCookieStatusResolver(
         }
 
         val disconnectedByUserId = couple.disconnectedByUserId ?: return CoupleCookieStatus.NOT_COUPLED
-        val partnerUserId = resolveCounterpartUserId(couple, userId, disconnectedByUserId)
-        if (partnerUserId != null) {
-            val partnerCouple = coupleRepository.findByUserIdFresh(partnerUserId)
-            if (partnerCouple != null && partnerCouple.id != couple.id && partnerCouple.isConnectedAndFull()) {
-                return CoupleCookieStatus.DISCONNECTED_EXPIRED
-            }
-        }
 
         return if (disconnectedByUserId == userId) {
             CoupleCookieStatus.DISCONNECTED_BY_ME
@@ -54,15 +47,4 @@ class CoupleCookieStatusResolver(
             CoupleCookieStatus.DISCONNECTED_BY_PARTNER
         }
     }
-
-    private fun resolveCounterpartUserId(
-        couple: Couple,
-        userId: Long,
-        disconnectedByUserId: Long,
-    ): Long? =
-        if (disconnectedByUserId == userId) {
-            couple.userIds.firstOrNull { it != userId }
-        } else {
-            disconnectedByUserId
-        }
 }

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCookieStatusResolver.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCookieStatusResolver.kt
@@ -11,7 +11,7 @@ class CoupleCookieStatusResolver(
     private val coupleRepository: CoupleRepositoryPort,
 ) {
     fun resolve(userId: Long): CoupleCookieStatus {
-        val currentCouple = coupleRepository.findByUserId(userId)
+        val currentCouple = coupleRepository.findByUserIdFresh(userId)
 
         if (currentCouple?.isConnectedAndFull() == true) {
             return CoupleCookieStatus.COUPLED
@@ -42,7 +42,7 @@ class CoupleCookieStatusResolver(
         val disconnectedByUserId = couple.disconnectedByUserId ?: return CoupleCookieStatus.NOT_COUPLED
         val partnerUserId = resolveCounterpartUserId(couple, userId, disconnectedByUserId)
         if (partnerUserId != null) {
-            val partnerCouple = coupleRepository.findByUserId(partnerUserId)
+            val partnerCouple = coupleRepository.findByUserIdFresh(partnerUserId)
             if (partnerCouple != null && partnerCouple.id != couple.id && partnerCouple.isConnectedAndFull()) {
                 return CoupleCookieStatus.DISCONNECTED_EXPIRED
             }

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCookieStatusResolver.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCookieStatusResolver.kt
@@ -25,6 +25,10 @@ class CoupleCookieStatusResolver(
             }
         }
 
+        if (currentCouple != null) {
+            return CoupleCookieStatus.NOT_COUPLED
+        }
+
         val disconnectedByMe = coupleRepository.findByDisconnectedByUserId(userId)
         if (disconnectedByMe?.status?.isDisconnectedOrExpired == true) {
             return CoupleCookieStatus.DISCONNECTED_BY_ME

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/application/port/CoupleRepositoryPort.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/application/port/CoupleRepositoryPort.kt
@@ -1,6 +1,7 @@
 package kr.co.lokit.api.domain.couple.application.port
 
 import kr.co.lokit.api.domain.couple.domain.Couple
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 interface CoupleRepositoryPort {
@@ -37,4 +38,6 @@ interface CoupleRepositoryPort {
     ): Couple
 
     fun findLatestJoinedAt(coupleId: Long): LocalDateTime?
+
+    fun updateFirstMetDate(coupleId: Long, firstMetDate: LocalDate)
 }

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/application/port/CoupleRepositoryPort.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/application/port/CoupleRepositoryPort.kt
@@ -22,6 +22,8 @@ interface CoupleRepositoryPort {
 
     fun findByUserId(userId: Long): Couple?
 
+    fun findByUserIdFresh(userId: Long): Couple?
+
     fun deleteById(id: Long)
 
     fun removeCoupleUser(userId: Long)

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/application/port/CoupleRepositoryPort.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/application/port/CoupleRepositoryPort.kt
@@ -2,7 +2,6 @@ package kr.co.lokit.api.domain.couple.application.port
 
 import kr.co.lokit.api.domain.couple.domain.Couple
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 interface CoupleRepositoryPort {
     fun save(couple: Couple): Couple
@@ -36,8 +35,6 @@ interface CoupleRepositoryPort {
         coupleId: Long,
         userId: Long,
     ): Couple
-
-    fun findLatestJoinedAt(coupleId: Long): LocalDateTime?
 
     fun updateFirstMetDate(coupleId: Long, firstMetDate: LocalDate)
 }

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/domain/Couple.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/domain/Couple.kt
@@ -2,6 +2,7 @@ package kr.co.lokit.api.domain.couple.domain
 
 import kr.co.lokit.api.common.constants.CoupleStatus
 import kr.co.lokit.api.common.constants.GracePeriodPolicy
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 data class Couple(
@@ -11,6 +12,7 @@ data class Couple(
     val status: CoupleStatus = CoupleStatus.CONNECTED,
     val disconnectedAt: LocalDateTime? = null,
     val disconnectedByUserId: Long? = null,
+    val firstMetDate: LocalDate? = null,
 ) {
     init {
         require(userIds.size <= MAX_MEMBERS)

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/dto/CoupleDto.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/dto/CoupleDto.kt
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Schema(description = "커플 생성 요청")
@@ -57,6 +59,13 @@ data class VerifyInviteCodeRequest(
     @field:Size(min = 6, max = 6, message = "초대 코드 형식이 잘못되었습니다.")
     @field:Pattern(regexp = "^\\d{6}$", message = "초대 코드 형식이 잘못되었습니다.")
     val inviteCode: String,
+)
+
+@Schema(description = "처음 만난 날짜 수정 요청")
+data class UpdateFirstMetDateRequest(
+    @field:NotNull(message = "처음 만난 날짜는 필수입니다")
+    @Schema(description = "처음 만난 날짜", example = "2024-01-01", requiredMode = Schema.RequiredMode.REQUIRED)
+    val firstMetDate: LocalDate,
 )
 
 @Schema(description = "초대코드 검증 응답")

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/infrastructure/CoupleEntity.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/infrastructure/CoupleEntity.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.OneToMany
 import kr.co.lokit.api.common.constants.CoupleStatus
 import kr.co.lokit.api.common.entity.BaseEntity
 import kr.co.lokit.api.domain.album.infrastructure.AlbumEntity
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Entity(name = "Couple")
@@ -21,6 +22,7 @@ class CoupleEntity(
     var status: CoupleStatus = CoupleStatus.CONNECTED,
     var disconnectedAt: LocalDateTime? = null,
     var disconnectedByUserId: Long? = null,
+    var firstMetDate: LocalDate? = null,
 ) : BaseEntity() {
     @OneToMany(
         fetch = FetchType.LAZY,

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/infrastructure/CoupleUserJpaRepository.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/infrastructure/CoupleUserJpaRepository.kt
@@ -3,13 +3,9 @@ package kr.co.lokit.api.domain.couple.infrastructure
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
-import java.time.LocalDateTime
 
 interface CoupleUserJpaRepository : JpaRepository<CoupleUserEntity, Long> {
     @Modifying
     @Query("DELETE FROM CoupleUser cu WHERE cu.user.id = :userId")
     fun deleteByUserId(userId: Long)
-
-    @Query("SELECT MAX(cu.createdAt) FROM CoupleUser cu WHERE cu.couple.id = :coupleId")
-    fun findLatestJoinedAtByCoupleId(coupleId: Long): LocalDateTime?
 }

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/infrastructure/JpaCoupleRepository.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/infrastructure/JpaCoupleRepository.kt
@@ -17,6 +17,7 @@ import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Repository
@@ -156,4 +157,12 @@ class JpaCoupleRepository(
     @Transactional(readOnly = true)
     override fun findLatestJoinedAt(coupleId: Long): LocalDateTime? =
         coupleUserJpaRepository.findLatestJoinedAtByCoupleId(coupleId)
+
+    @Transactional
+    override fun updateFirstMetDate(coupleId: Long, firstMetDate: LocalDate) {
+        val entity =
+            coupleJpaRepository.findByIdOrNull(coupleId)
+                ?: throw entityNotFound<Couple>(coupleId)
+        entity.firstMetDate = firstMetDate
+    }
 }

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/infrastructure/JpaCoupleRepository.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/infrastructure/JpaCoupleRepository.kt
@@ -18,7 +18,6 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 @Repository
 class JpaCoupleRepository(
@@ -153,10 +152,6 @@ class JpaCoupleRepository(
         entity.addUser(CoupleUserEntity(couple = entity, user = userEntity))
         return entity.toDomain()
     }
-
-    @Transactional(readOnly = true)
-    override fun findLatestJoinedAt(coupleId: Long): LocalDateTime? =
-        coupleUserJpaRepository.findLatestJoinedAtByCoupleId(coupleId)
 
     @Transactional
     override fun updateFirstMetDate(coupleId: Long, firstMetDate: LocalDate) {

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/infrastructure/mapping/CoupleEntityMappings.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/infrastructure/mapping/CoupleEntityMappings.kt
@@ -12,6 +12,7 @@ fun Couple.toEntity(): CoupleEntity =
         status = status,
         disconnectedAt = disconnectedAt,
         disconnectedByUserId = disconnectedByUserId,
+        firstMetDate = firstMetDate,
     )
 
 fun CoupleEntity.toDomain(): Couple =
@@ -22,6 +23,7 @@ fun CoupleEntity.toDomain(): Couple =
         status = status,
         disconnectedAt = disconnectedAt,
         disconnectedByUserId = disconnectedByUserId,
+        firstMetDate = firstMetDate,
     )
 
 fun InviteCodeEntity.toDomain(): InviteCode =

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/presentation/CoupleApi.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/presentation/CoupleApi.kt
@@ -11,6 +11,7 @@ import kr.co.lokit.api.domain.couple.dto.CoupleStatusResponse
 import kr.co.lokit.api.domain.couple.dto.InviteCodePreviewResponse
 import kr.co.lokit.api.domain.couple.dto.InviteCodeResponse
 import kr.co.lokit.api.domain.couple.dto.JoinCoupleRequest
+import kr.co.lokit.api.domain.couple.dto.UpdateFirstMetDateRequest
 import kr.co.lokit.api.domain.couple.dto.VerifyInviteCodeRequest
 
 @SecurityRequirement(name = "Authorization")
@@ -106,5 +107,18 @@ interface CoupleApi {
         @Parameter(hidden = true) userId: Long,
         @Parameter(hidden = true) req: HttpServletRequest,
         @Parameter(hidden = true) res: HttpServletResponse,
+    )
+
+    @Operation(
+        summary = "처음 만난 날짜 수정",
+        description = "커플의 처음 만난 날짜(기념일)를 수정합니다.",
+        responses = [
+            ApiResponse(responseCode = "204", description = "수정 성공"),
+            ApiResponse(responseCode = "404", description = "커플을 찾을 수 없음"),
+        ],
+    )
+    fun updateFirstMetDate(
+        request: UpdateFirstMetDateRequest,
+        @Parameter(hidden = true) userId: Long,
     )
 }

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/presentation/CoupleController.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/presentation/CoupleController.kt
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
 import kr.co.lokit.api.common.annotation.CurrentUserId
 import kr.co.lokit.api.config.web.CookieGenerator
+import kr.co.lokit.api.domain.couple.application.CoupleCommandService
 import kr.co.lokit.api.domain.couple.application.CoupleCookieStatusResolver
 import kr.co.lokit.api.domain.couple.application.port.`in`.CoupleInviteUseCase
 import kr.co.lokit.api.domain.couple.application.port.`in`.DisconnectCoupleUseCase
@@ -13,12 +14,14 @@ import kr.co.lokit.api.domain.couple.dto.CoupleStatusResponse
 import kr.co.lokit.api.domain.couple.dto.InviteCodePreviewResponse
 import kr.co.lokit.api.domain.couple.dto.InviteCodeResponse
 import kr.co.lokit.api.domain.couple.dto.JoinCoupleRequest
+import kr.co.lokit.api.domain.couple.dto.UpdateFirstMetDateRequest
 import kr.co.lokit.api.domain.couple.dto.VerifyInviteCodeRequest
 import kr.co.lokit.api.domain.couple.presentation.mapping.toResponse
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -31,6 +34,7 @@ class CoupleController(
     private val disconnectCoupleUseCase: DisconnectCoupleUseCase,
     private val reconnectCoupleUseCase: ReconnectCoupleUseCase,
     private val coupleInviteUseCase: CoupleInviteUseCase,
+    private val coupleCommandService: CoupleCommandService,
     private val coupleCookieStatusResolver: CoupleCookieStatusResolver,
     private val cookieGenerator: CookieGenerator,
 ) : CoupleApi {
@@ -115,6 +119,15 @@ class CoupleController(
     ) {
         disconnectCoupleUseCase.disconnect(userId)
         setCoupleStatusCookie(userId, req, res)
+    }
+
+    @PatchMapping("me/first-met-date")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    override fun updateFirstMetDate(
+        @RequestBody @Valid request: UpdateFirstMetDateRequest,
+        @CurrentUserId userId: Long,
+    ) {
+        coupleCommandService.updateFirstMetDate(userId, request.firstMetDate)
     }
 
     private fun setCoupleStatusCookie(

--- a/src/main/kotlin/kr/co/lokit/api/domain/couple/presentation/CoupleController.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/couple/presentation/CoupleController.kt
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
 import kr.co.lokit.api.common.annotation.CurrentUserId
+import kr.co.lokit.api.config.cache.evictUserCoupleCache
 import kr.co.lokit.api.config.web.CookieGenerator
 import kr.co.lokit.api.domain.couple.application.CoupleCommandService
 import kr.co.lokit.api.domain.couple.application.CoupleCookieStatusResolver
@@ -19,6 +20,7 @@ import kr.co.lokit.api.domain.couple.dto.VerifyInviteCodeRequest
 import kr.co.lokit.api.domain.couple.presentation.mapping.toResponse
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.cache.CacheManager
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -37,6 +39,7 @@ class CoupleController(
     private val coupleCommandService: CoupleCommandService,
     private val coupleCookieStatusResolver: CoupleCookieStatusResolver,
     private val cookieGenerator: CookieGenerator,
+    private val cacheManager: CacheManager,
 ) : CoupleApi {
     @GetMapping("me/status")
     override fun getMyStatus(
@@ -135,6 +138,7 @@ class CoupleController(
         req: HttpServletRequest,
         res: HttpServletResponse,
     ) {
+        cacheManager.evictUserCoupleCache(userId)
         val coupleStatus = coupleCookieStatusResolver.resolve(userId)
         res.addHeader(HttpHeaders.SET_COOKIE, cookieGenerator.createCoupleStatusCookie(req, coupleStatus).toString())
     }

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/application/AuthService.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/application/AuthService.kt
@@ -19,6 +19,11 @@ class AuthService(
     private val jwtTokenProvider: JwtTokenProvider,
 ) {
     @Transactional
+    fun logout(userId: Long) {
+        refreshTokenRepository.deleteByUserId(userId)
+    }
+
+    @Transactional
     fun refreshIfValid(refreshToken: String): AuthTokens? {
         val refreshTokenRecord = refreshTokenRepository.findByToken(refreshToken) ?: return null
 

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/application/MyPageService.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/application/MyPageService.kt
@@ -44,12 +44,15 @@ class MyPageService(
 
         val couplePhotoCount = couple?.let { photoRepository.countByCoupleId(it.id) } ?: 0L
 
+        val firstMetDate = if (isCoupled) requireNotNull(couple).firstMetDate else null
+
         return MyPageReadModel(
             myEmail = me.email,
             myName = me.name,
             myProfileImageUrl = me.profileImageUrl,
             partnerName = partner?.name,
             partnerProfileImageUrl = partner?.profileImageUrl,
+            firstMetDate = firstMetDate,
             coupledDay = coupledDay,
             couplePhotoCount = couplePhotoCount,
         )

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/application/MyPageService.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/application/MyPageService.kt
@@ -45,6 +45,7 @@ class MyPageService(
         val couplePhotoCount = couple?.let { photoRepository.countByCoupleId(it.id) } ?: 0L
 
         return MyPageReadModel(
+            myEmail = me.email,
             myName = me.name,
             myProfileImageUrl = me.profileImageUrl,
             partnerName = partner?.name,

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/application/MyPageService.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/application/MyPageService.kt
@@ -11,7 +11,6 @@ import kr.co.lokit.api.domain.user.domain.User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
 @Service
@@ -40,9 +39,7 @@ class MyPageService(
             if (!isCoupled) {
                 null
             } else {
-                val coupledGroup = requireNotNull(couple)
-                val connectedAt = coupleRepository.findLatestJoinedAt(coupledGroup.id)
-                connectedAt.toDDay()
+                requireNotNull(couple).firstMetDate?.toDDay()
             }
 
         val couplePhotoCount = couple?.let { photoRepository.countByCoupleId(it.id) } ?: 0L
@@ -75,9 +72,9 @@ class MyPageService(
         return userRepository.update(user.withProfileImage(profileImageUrl))
     }
 
-    private fun LocalDateTime?.toDDay(): Long? {
+    private fun LocalDate?.toDDay(): Long? {
         if (this == null) return null
-        val days = ChronoUnit.DAYS.between(this.toLocalDate(), LocalDate.now()) + 1
+        val days = ChronoUnit.DAYS.between(this, LocalDate.now()) + 1
         return days.takeIf { it >= 0 }
     }
 }

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/application/UserWithdrawService.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/application/UserWithdrawService.kt
@@ -35,7 +35,7 @@ class UserWithdrawService(
 
         // 2. 회원 탈퇴는 반드시 연결 끊기 완료 후에만 허용
         val couple = coupleRepository.findByUserId(userId)
-        if (couple != null) {
+        if (couple != null && couple.isConnectedAndFull()) {
             throw BusinessException.UserDisconnectRequiredException(
                 errors =
                     errorDetailsOf(

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/domain/MyPageReadModel.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/domain/MyPageReadModel.kt
@@ -1,11 +1,14 @@
 package kr.co.lokit.api.domain.user.domain
 
+import java.time.LocalDate
+
 data class MyPageReadModel(
     val myEmail: String,
     val myName: String,
     val myProfileImageUrl: String?,
     val partnerName: String?,
     val partnerProfileImageUrl: String?,
+    val firstMetDate: LocalDate?,
     val coupledDay: Long?,
     val couplePhotoCount: Long,
 )

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/domain/MyPageReadModel.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/domain/MyPageReadModel.kt
@@ -1,6 +1,7 @@
 package kr.co.lokit.api.domain.user.domain
 
 data class MyPageReadModel(
+    val myEmail: String,
     val myName: String,
     val myProfileImageUrl: String?,
     val partnerName: String?,

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/dto/MyPageDto.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/dto/MyPageDto.kt
@@ -3,6 +3,7 @@ package kr.co.lokit.api.domain.user.dto
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
+import java.time.LocalDate
 
 @Schema(description = "닉네임 수정 요청")
 data class UpdateNicknameRequest(
@@ -35,7 +36,9 @@ data class MyPageResponse(
     val partnerName: String?,
     @Schema(description = "상대방 프로필 이미지 URL", example = "https://example.com/partner.jpg")
     val partnerProfileImageUrl: String?,
-    @Schema(description = "로킷을 커플 연결한 이후 지금까지의 사용한 날짜 (미연결 시 null)", example = "100")
+    @Schema(description = "처음 만난 날짜 (미설정 시 null)", example = "2024-11-09")
+    val firstMetDate: LocalDate?,
+    @Schema(description = "처음 만난 날짜 기준 D-Day (미설정 시 null)", example = "100")
     val coupledDay: Long?,
     @Schema(description = "커플 내 전체 사진 수", example = "128")
     val couplePhotoCount: Long,

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/dto/MyPageDto.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/dto/MyPageDto.kt
@@ -25,6 +25,8 @@ data class UpdateProfileImageRequest(
 
 @Schema(description = "마이페이지 조회 응답")
 data class MyPageResponse(
+    @Schema(description = "내 이메일", example = "user@example.com")
+    val myEmail: String,
     @Schema(description = "내 닉네임", example = "홍로킷")
     val myName: String,
     @Schema(description = "내 프로필 이미지 URL", example = "https://example.com/me.jpg")

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/presentation/AuthApi.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/presentation/AuthApi.kt
@@ -4,9 +4,11 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.security.SecurityRequirements
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestParam
 
@@ -37,4 +39,20 @@ interface AuthApi {
         @RequestParam(required = false) state: String?,
         @Parameter(hidden = true) req: HttpServletRequest,
     ): ResponseEntity<Unit>
+
+    @SecurityRequirement(name = "Authorization")
+    @Operation(
+        summary = "로그아웃",
+        description = "현재 로그인된 사용자의 세션을 종료합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "로그아웃 성공"),
+        ],
+    )
+    fun logout(
+        @Parameter(hidden = true) userId: Long,
+        @Parameter(hidden = true) req: HttpServletRequest,
+        @Parameter(hidden = true) res: HttpServletResponse,
+    )
 }

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/presentation/AuthController.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/presentation/AuthController.kt
@@ -83,14 +83,11 @@ class AuthController(
             val loginResult = loginService.login(code)
             val accessTokenCookie = cookieGenerator.createAccessTokenCookie(req, loginResult.tokens.accessToken)
             val refreshTokenCookie = cookieGenerator.createRefreshTokenCookie(req, loginResult.tokens.refreshToken)
-            val coupleStatusCookie =
-                cookieGenerator.createCoupleStatusCookie(req, coupleCookieStatusResolver.resolve(loginResult.userId))
 
             ResponseEntity
                 .status(HttpStatus.FOUND)
                 .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
                 .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
-                .header(HttpHeaders.SET_COOKIE, coupleStatusCookie.toString())
                 .location(URI.create(redirectUri))
                 .build()
         } catch (ex: BusinessException) {

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/presentation/AuthController.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/presentation/AuthController.kt
@@ -1,10 +1,13 @@
 package kr.co.lokit.api.domain.user.presentation
 
 import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import kr.co.lokit.api.common.annotation.CurrentUserId
 import kr.co.lokit.api.common.exception.BusinessException
 import kr.co.lokit.api.common.exception.ErrorCode
 import kr.co.lokit.api.config.web.CookieGenerator
 import kr.co.lokit.api.domain.couple.application.CoupleCookieStatusResolver
+import kr.co.lokit.api.domain.user.application.AuthService
 import kr.co.lokit.api.domain.user.application.LoginService
 import kr.co.lokit.api.domain.user.infrastructure.oauth.KakaoOAuthProperties
 import org.slf4j.LoggerFactory
@@ -13,6 +16,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -27,6 +31,7 @@ import java.nio.charset.StandardCharsets
 @RequestMapping("auth")
 class AuthController(
     private val loginService: LoginService,
+    private val authService: AuthService,
     private val kakaoOAuthProperties: KakaoOAuthProperties,
     private val coupleCookieStatusResolver: CoupleCookieStatusResolver,
     private val cookieGenerator: CookieGenerator,
@@ -101,6 +106,19 @@ class AuthController(
                 .location(URI.create(buildErrorRedirectUri(redirectUri, ErrorCode.INTERNAL_SERVER_ERROR.code)))
                 .build()
         }
+    }
+
+    @PostMapping("logout")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    override fun logout(
+        @CurrentUserId userId: Long,
+        req: HttpServletRequest,
+        res: HttpServletResponse,
+    ) {
+        authService.logout(userId)
+        res.addHeader(HttpHeaders.SET_COOKIE, cookieGenerator.clearAccessTokenCookie(req).toString())
+        res.addHeader(HttpHeaders.SET_COOKIE, cookieGenerator.clearRefreshTokenCookie(req).toString())
+        res.addHeader(HttpHeaders.SET_COOKIE, cookieGenerator.clearCoupleStatusCookie(req).toString())
     }
 
     private fun resolveRedirectFromReferer(req: HttpServletRequest): String? {

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/presentation/mapping/MyPageDtoMappings.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/presentation/mapping/MyPageDtoMappings.kt
@@ -10,6 +10,7 @@ fun MyPageReadModel.toResponse(): MyPageResponse =
         myProfileImageUrl = myProfileImageUrl,
         partnerName = partnerName,
         partnerProfileImageUrl = partnerProfileImageUrl,
+        firstMetDate = firstMetDate,
         coupledDay = coupledDay,
         couplePhotoCount = couplePhotoCount,
     )

--- a/src/main/kotlin/kr/co/lokit/api/domain/user/presentation/mapping/MyPageDtoMappings.kt
+++ b/src/main/kotlin/kr/co/lokit/api/domain/user/presentation/mapping/MyPageDtoMappings.kt
@@ -5,6 +5,7 @@ import kr.co.lokit.api.domain.user.dto.MyPageResponse
 
 fun MyPageReadModel.toResponse(): MyPageResponse =
     MyPageResponse(
+        myEmail = myEmail,
         myName = myName,
         myProfileImageUrl = myProfileImageUrl,
         partnerName = partnerName,

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -34,13 +34,13 @@ spring:
     task:
         execution:
             pool:
-                core-size: 8
-                max-size: 50
+                core-size: 4
+                max-size: 24
 server:
     tomcat:
         threads:
-            max: 50
-            min-spare: 10
+            max: 80
+            min-spare: 8
         max-connections: 500
         accept-count: 100
         connection-timeout: 10s

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -34,14 +34,14 @@ spring:
     task:
         execution:
             pool:
-                core-size: 8
-                max-size: 50
+                core-size: 4
+                max-size: 24
 
 server:
     tomcat:
         threads:
-            max: 100
-            min-spare: 10
+            max: 80
+            min-spare: 8
         max-connections: 1000
         accept-count: 200
         connection-timeout: 10s

--- a/src/test/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCookieStatusResolverTest.kt
+++ b/src/test/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCookieStatusResolverTest.kt
@@ -44,7 +44,7 @@ class CoupleCookieStatusResolverTest {
     }
 
     @Test
-    fun `currentCouple가 없어도 reconnect 대상이 없으면 DISCONNECTED_EXPIRED를 반환한다`() {
+    fun `currentCouple가 없어도 31일 내 disconnect 이력이 있으면 DISCONNECTED_BY_ME를 반환한다`() {
         val userId = 1L
         val disconnectedByMe =
             createCouple(
@@ -52,6 +52,7 @@ class CoupleCookieStatusResolverTest {
                 name = "old",
                 userIds = emptyList(),
                 status = CoupleStatus.DISCONNECTED,
+                disconnectedAt = LocalDateTime.now().minusDays(2),
                 disconnectedByUserId = userId,
             )
 
@@ -60,7 +61,7 @@ class CoupleCookieStatusResolverTest {
 
         val result = coupleCookieStatusResolver.resolve(userId)
 
-        assertEquals(CoupleCookieStatus.DISCONNECTED_EXPIRED, result)
+        assertEquals(CoupleCookieStatus.DISCONNECTED_BY_ME, result)
     }
 
     @Test

--- a/src/test/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCookieStatusResolverTest.kt
+++ b/src/test/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCookieStatusResolverTest.kt
@@ -34,7 +34,7 @@ class CoupleCookieStatusResolverTest {
                 status = CoupleStatus.CONNECTED,
             )
 
-        `when`(coupleRepository.findByUserId(userId)).thenReturn(currentCouple)
+        `when`(coupleRepository.findByUserIdFresh(userId)).thenReturn(currentCouple)
         `when`(coupleRepository.findByDisconnectedByUserId(userId)).thenReturn(null)
 
         val result = coupleCookieStatusResolver.resolve(userId)
@@ -55,7 +55,7 @@ class CoupleCookieStatusResolverTest {
                 disconnectedByUserId = userId,
             )
 
-        `when`(coupleRepository.findByUserId(userId)).thenReturn(null)
+        `when`(coupleRepository.findByUserIdFresh(userId)).thenReturn(null)
         `when`(coupleRepository.findByDisconnectedByUserId(userId)).thenReturn(disconnectedByMe)
 
         val result = coupleCookieStatusResolver.resolve(userId)
@@ -93,9 +93,9 @@ class CoupleCookieStatusResolverTest {
                 disconnectedByUserId = userId,
             )
 
-        `when`(coupleRepository.findByUserId(userId)).thenReturn(currentSoloCouple)
+        `when`(coupleRepository.findByUserIdFresh(userId)).thenReturn(currentSoloCouple)
         `when`(coupleRepository.findByDisconnectedByUserId(userId)).thenReturn(disconnectedByMe)
-        `when`(coupleRepository.findByUserId(partnerId)).thenReturn(partnerCurrentCouple)
+        `when`(coupleRepository.findByUserIdFresh(partnerId)).thenReturn(partnerCurrentCouple)
 
         val result = coupleCookieStatusResolver.resolve(userId)
 
@@ -116,8 +116,8 @@ class CoupleCookieStatusResolverTest {
                 disconnectedByUserId = partner,
             )
 
-        `when`(coupleRepository.findByUserId(me)).thenReturn(disconnectedByPartner)
-        `when`(coupleRepository.findByUserId(partner)).thenReturn(null)
+        `when`(coupleRepository.findByUserIdFresh(me)).thenReturn(disconnectedByPartner)
+        `when`(coupleRepository.findByUserIdFresh(partner)).thenReturn(null)
 
         val result = coupleCookieStatusResolver.resolve(me)
 
@@ -139,12 +139,12 @@ class CoupleCookieStatusResolverTest {
                 disconnectedByUserId = partner,
             )
 
-        `when`(coupleRepository.findByUserId(me)).thenReturn(expiredDisconnected)
+        `when`(coupleRepository.findByUserIdFresh(me)).thenReturn(expiredDisconnected)
 
         val result = coupleCookieStatusResolver.resolve(me)
 
         assertEquals(CoupleCookieStatus.DISCONNECTED_EXPIRED, result)
-        verify(coupleRepository, never()).findByUserId(partner)
+        verify(coupleRepository, never()).findByUserIdFresh(partner)
         verify(coupleRepository, never()).findByDisconnectedByUserId(me)
     }
 }

--- a/src/test/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCookieStatusResolverTest.kt
+++ b/src/test/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCookieStatusResolverTest.kt
@@ -83,19 +83,9 @@ class CoupleCookieStatusResolverTest {
                 disconnectedAt = LocalDateTime.now().minusDays(5),
                 disconnectedByUserId = userId,
             )
-        val partnerCurrentCouple =
-            createCouple(
-                id = 200L,
-                name = "old",
-                userIds = listOf(partnerId),
-                status = CoupleStatus.DISCONNECTED,
-                disconnectedAt = LocalDateTime.now().minusDays(5),
-                disconnectedByUserId = userId,
-            )
 
         `when`(coupleRepository.findByUserIdFresh(userId)).thenReturn(currentSoloCouple)
         `when`(coupleRepository.findByDisconnectedByUserId(userId)).thenReturn(disconnectedByMe)
-        `when`(coupleRepository.findByUserIdFresh(partnerId)).thenReturn(partnerCurrentCouple)
 
         val result = coupleCookieStatusResolver.resolve(userId)
 
@@ -105,7 +95,6 @@ class CoupleCookieStatusResolverTest {
     @Test
     fun `상대가 나가고 나는 남아있는 경우 DISCONNECTED_BY_PARTNER를 반환한다`() {
         val me = 2L
-        val partner = 1L
         val disconnectedByPartner =
             createCouple(
                 id = 300L,
@@ -113,11 +102,10 @@ class CoupleCookieStatusResolverTest {
                 userIds = listOf(me),
                 status = CoupleStatus.DISCONNECTED,
                 disconnectedAt = LocalDateTime.now().minusDays(10),
-                disconnectedByUserId = partner,
+                disconnectedByUserId = 1L,
             )
 
         `when`(coupleRepository.findByUserIdFresh(me)).thenReturn(disconnectedByPartner)
-        `when`(coupleRepository.findByUserIdFresh(partner)).thenReturn(null)
 
         val result = coupleCookieStatusResolver.resolve(me)
 

--- a/src/test/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCookieStatusResolverTest.kt
+++ b/src/test/kotlin/kr/co/lokit/api/domain/couple/application/CoupleCookieStatusResolverTest.kt
@@ -1,0 +1,109 @@
+package kr.co.lokit.api.domain.couple.application
+
+import kr.co.lokit.api.common.constants.CoupleCookieStatus
+import kr.co.lokit.api.common.constants.CoupleStatus
+import kr.co.lokit.api.domain.couple.application.port.CoupleRepositoryPort
+import kr.co.lokit.api.fixture.createCouple
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+class CoupleCookieStatusResolverTest {
+    @Mock
+    lateinit var coupleRepository: CoupleRepositoryPort
+
+    @InjectMocks
+    lateinit var coupleCookieStatusResolver: CoupleCookieStatusResolver
+
+    @Test
+    fun `현재 커플이 CONNECTED 단독 상태면 NOT_COUPLED를 반환한다`() {
+        val userId = 1L
+        val currentCouple =
+            createCouple(
+                id = 100L,
+                name = "default",
+                userIds = listOf(userId),
+                status = CoupleStatus.CONNECTED,
+            )
+
+        `when`(coupleRepository.findByUserId(userId)).thenReturn(currentCouple)
+
+        val result = coupleCookieStatusResolver.resolve(userId)
+
+        assertEquals(CoupleCookieStatus.NOT_COUPLED, result)
+        verify(coupleRepository, never()).findByDisconnectedByUserId(userId)
+    }
+
+    @Test
+    fun `currentCouple가 없을 때만 disconnectedByMe fallback을 사용한다`() {
+        val userId = 1L
+        val disconnectedByMe =
+            createCouple(
+                id = 200L,
+                name = "old",
+                status = CoupleStatus.DISCONNECTED,
+                disconnectedByUserId = userId,
+            )
+
+        `when`(coupleRepository.findByUserId(userId)).thenReturn(null)
+        `when`(coupleRepository.findByDisconnectedByUserId(userId)).thenReturn(disconnectedByMe)
+
+        val result = coupleCookieStatusResolver.resolve(userId)
+
+        assertEquals(CoupleCookieStatus.DISCONNECTED_BY_ME, result)
+    }
+
+    @Test
+    fun `상대가 나가고 나는 남아있는 경우 DISCONNECTED_BY_PARTNER를 반환한다`() {
+        val me = 2L
+        val partner = 1L
+        val disconnectedByPartner =
+            createCouple(
+                id = 300L,
+                name = "old-couple",
+                userIds = listOf(me),
+                status = CoupleStatus.DISCONNECTED,
+                disconnectedAt = LocalDateTime.now().minusDays(10),
+                disconnectedByUserId = partner,
+            )
+
+        `when`(coupleRepository.findByUserId(me)).thenReturn(disconnectedByPartner)
+        `when`(coupleRepository.findByUserId(partner)).thenReturn(null)
+
+        val result = coupleCookieStatusResolver.resolve(me)
+
+        assertEquals(CoupleCookieStatus.DISCONNECTED_BY_PARTNER, result)
+        verify(coupleRepository, never()).findByDisconnectedByUserId(me)
+    }
+
+    @Test
+    fun `상대가 나가고 31일 초과면 DISCONNECTED_EXPIRED를 반환한다`() {
+        val me = 2L
+        val partner = 1L
+        val expiredDisconnected =
+            createCouple(
+                id = 301L,
+                name = "old-couple",
+                userIds = listOf(me),
+                status = CoupleStatus.DISCONNECTED,
+                disconnectedAt = LocalDateTime.now().minusDays(32),
+                disconnectedByUserId = partner,
+            )
+
+        `when`(coupleRepository.findByUserId(me)).thenReturn(expiredDisconnected)
+
+        val result = coupleCookieStatusResolver.resolve(me)
+
+        assertEquals(CoupleCookieStatus.DISCONNECTED_EXPIRED, result)
+        verify(coupleRepository, never()).findByUserId(partner)
+        verify(coupleRepository, never()).findByDisconnectedByUserId(me)
+    }
+}

--- a/src/test/kotlin/kr/co/lokit/api/domain/couple/application/CoupleInviteServiceTest.kt
+++ b/src/test/kotlin/kr/co/lokit/api/domain/couple/application/CoupleInviteServiceTest.kt
@@ -2,6 +2,7 @@ package kr.co.lokit.api.domain.couple.application
 
 import kr.co.lokit.api.domain.couple.application.port.CoupleRepositoryPort
 import kr.co.lokit.api.domain.couple.application.port.InviteCodeRepositoryPort
+import kr.co.lokit.api.domain.couple.application.port.`in`.CreateCoupleUseCase
 import kr.co.lokit.api.domain.couple.domain.InviteCode
 import kr.co.lokit.api.domain.couple.domain.InviteCodeStatus
 import kr.co.lokit.api.domain.couple.domain.InviteIssuer
@@ -41,6 +42,9 @@ class CoupleInviteServiceTest {
     @Mock
     lateinit var coupleProfileImageUrlResolver: CoupleProfileImageUrlResolver
 
+    @Mock
+    lateinit var createCoupleUseCase: CreateCoupleUseCase
+
     lateinit var coupleInviteService: CoupleInviteService
 
     @BeforeEach
@@ -54,6 +58,7 @@ class CoupleInviteServiceTest {
                 cacheManager = cacheManager,
                 rateLimiter = CoupleInviteRateLimiter(),
                 coupleProfileImageUrlResolver = coupleProfileImageUrlResolver,
+                createCoupleUseCase = createCoupleUseCase,
             )
     }
 

--- a/src/test/kotlin/kr/co/lokit/api/domain/couple/application/CoupleServiceTest.kt
+++ b/src/test/kotlin/kr/co/lokit/api/domain/couple/application/CoupleServiceTest.kt
@@ -14,6 +14,7 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.springframework.cache.CacheManager
 import java.time.LocalDate
 import kotlin.test.assertEquals
 
@@ -27,6 +28,9 @@ class CoupleServiceTest {
 
     @Mock
     lateinit var coupleProfileImageUrlResolver: CoupleProfileImageUrlResolver
+
+    @Mock
+    lateinit var cacheManager: CacheManager
 
     @InjectMocks
     lateinit var coupleCommandService: CoupleCommandService

--- a/src/test/kotlin/kr/co/lokit/api/domain/couple/application/CoupleServiceTest.kt
+++ b/src/test/kotlin/kr/co/lokit/api/domain/couple/application/CoupleServiceTest.kt
@@ -1,10 +1,12 @@
 package kr.co.lokit.api.domain.couple.application
 
+import kr.co.lokit.api.common.exception.BusinessException
 import kr.co.lokit.api.domain.couple.application.port.CoupleRepositoryPort
 import kr.co.lokit.api.domain.user.application.port.UserRepositoryPort
 import kr.co.lokit.api.fixture.createUser
 import kr.co.lokit.api.fixture.createCouple
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
@@ -12,6 +14,7 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import java.time.LocalDate
 import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
@@ -53,5 +56,25 @@ class CoupleServiceTest {
 
         assertEquals(10L, result.id)
         verify(coupleRepository).findByUserId(1L)
+    }
+
+    @Test
+    fun `처음 만난 날짜를 수정한다`() {
+        val couple = createCouple(id = 1L, name = "우리 커플", userIds = listOf(1L, 2L))
+        val newDate = LocalDate.of(2024, 6, 15)
+        `when`(coupleRepository.findByUserId(1L)).thenReturn(couple)
+
+        coupleCommandService.updateFirstMetDate(1L, newDate)
+
+        verify(coupleRepository).updateFirstMetDate(1L, newDate)
+    }
+
+    @Test
+    fun `처음 만난 날짜 수정 시 커플이 없으면 예외가 발생한다`() {
+        `when`(coupleRepository.findByUserId(1L)).thenReturn(null)
+
+        assertThrows<BusinessException.CoupleNotFoundException> {
+            coupleCommandService.updateFirstMetDate(1L, LocalDate.of(2024, 1, 1))
+        }
     }
 }

--- a/src/test/kotlin/kr/co/lokit/api/domain/couple/presentation/CoupleControllerTest.kt
+++ b/src/test/kotlin/kr/co/lokit/api/domain/couple/presentation/CoupleControllerTest.kt
@@ -29,6 +29,7 @@ import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.doThrow
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.cache.CacheManager
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseCookie
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication
@@ -81,6 +82,9 @@ class CoupleControllerTest {
 
     @MockitoBean
     lateinit var coupleCommandService: CoupleCommandService
+
+    @MockitoBean
+    lateinit var cacheManager: CacheManager
 
     @Test
     fun `커플 생성 엔드포인트 없음`() {

--- a/src/test/kotlin/kr/co/lokit/api/domain/couple/presentation/CoupleControllerTest.kt
+++ b/src/test/kotlin/kr/co/lokit/api/domain/couple/presentation/CoupleControllerTest.kt
@@ -7,6 +7,7 @@ import kr.co.lokit.api.config.security.JwtTokenProvider
 import kr.co.lokit.api.config.web.CookieGenerator
 import kr.co.lokit.api.config.web.CookieProperties
 import kr.co.lokit.api.common.constants.CoupleCookieStatus
+import kr.co.lokit.api.domain.couple.application.CoupleCommandService
 import kr.co.lokit.api.domain.couple.application.CoupleCookieStatusResolver
 import kr.co.lokit.api.domain.couple.application.port.`in`.CoupleInviteUseCase
 import kr.co.lokit.api.domain.couple.application.port.`in`.CreateCoupleUseCase
@@ -73,6 +74,9 @@ class CoupleControllerTest {
 
     @MockitoBean
     lateinit var coupleInviteUseCase: CoupleInviteUseCase
+
+    @MockitoBean
+    lateinit var coupleCommandService: CoupleCommandService
 
     @Test
     fun `커플 생성 엔드포인트 없음`() {

--- a/src/test/kotlin/kr/co/lokit/api/domain/user/application/AuthServiceTest.kt
+++ b/src/test/kotlin/kr/co/lokit/api/domain/user/application/AuthServiceTest.kt
@@ -103,6 +103,13 @@ class AuthServiceTest {
     }
 
     @Test
+    fun `로그아웃 시 리프레시 토큰이 삭제된다`() {
+        authService.logout(1L)
+
+        verify(refreshTokenRepository).deleteByUserId(1L)
+    }
+
+    @Test
     fun `사용자를 찾을 수 없으면 UserNotFoundException이 발생한다`() {
         val refreshTokenRecord =
             RefreshTokenRecord(

--- a/src/test/kotlin/kr/co/lokit/api/domain/user/application/MyPageServiceTest.kt
+++ b/src/test/kotlin/kr/co/lokit/api/domain/user/application/MyPageServiceTest.kt
@@ -4,6 +4,7 @@ import kr.co.lokit.api.common.exception.BusinessException
 import kr.co.lokit.api.domain.couple.application.port.CoupleRepositoryPort
 import kr.co.lokit.api.domain.photo.application.port.PhotoRepositoryPort
 import kr.co.lokit.api.domain.user.application.port.UserRepositoryPort
+import kr.co.lokit.api.fixture.createCouple
 import kr.co.lokit.api.fixture.createUser
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -13,7 +14,9 @@ import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDate
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 @ExtendWith(MockitoExtension::class)
 class MyPageServiceTest {
@@ -56,7 +59,9 @@ class MyPageServiceTest {
         val user = createUser(id = 1L)
         val updatedUser = createUser(id = 1L).apply { profileImageUrl = "https://example.com/new.jpg" }
         `when`(userRepository.findById(1L)).thenReturn(user)
-        `when`(userRepository.update(user.copy(profileImageUrl = "https://example.com/new.jpg"))).thenReturn(updatedUser)
+        `when`(
+            userRepository.update(user.copy(profileImageUrl = "https://example.com/new.jpg")),
+        ).thenReturn(updatedUser)
 
         val result = myPageService.updateProfileImage(1L, "https://example.com/new.jpg")
 
@@ -71,5 +76,57 @@ class MyPageServiceTest {
         assertThrows<BusinessException.ResourceNotFoundException> {
             myPageService.updateProfileImage(1L, "https://example.com/new.jpg")
         }
+    }
+
+    @Test
+    fun `firstMetDate가 설정되어 있으면 coupledDay가 계산된다`() {
+        val me = createUser(id = 1L, name = "나")
+        val partner = createUser(id = 2L, name = "파트너")
+        val couple =
+            createCouple(
+                id = 1L,
+                userIds = listOf(1L, 2L),
+                firstMetDate = LocalDate.now().minusDays(9),
+            )
+        `when`(userRepository.findById(1L)).thenReturn(me)
+        `when`(userRepository.findById(2L)).thenReturn(partner)
+        `when`(coupleRepository.findByUserId(1L)).thenReturn(couple)
+        `when`(photoRepository.countByCoupleId(1L)).thenReturn(5L)
+
+        val result = myPageService.getMyPage(1L)
+
+        assertEquals(10L, result.coupledDay)
+    }
+
+    @Test
+    fun `firstMetDate가 설정되지 않으면 coupledDay가 null이다`() {
+        val me = createUser(id = 1L, name = "나")
+        val partner = createUser(id = 2L, name = "파트너")
+        val couple =
+            createCouple(
+                id = 1L,
+                userIds = listOf(1L, 2L),
+                firstMetDate = null,
+            )
+        `when`(userRepository.findById(1L)).thenReturn(me)
+        `when`(userRepository.findById(2L)).thenReturn(partner)
+        `when`(coupleRepository.findByUserId(1L)).thenReturn(couple)
+        `when`(photoRepository.countByCoupleId(1L)).thenReturn(0L)
+
+        val result = myPageService.getMyPage(1L)
+
+        assertNull(result.coupledDay)
+    }
+
+    @Test
+    fun `커플이 아니면 coupledDay가 null이다`() {
+        val me = createUser(id = 1L, name = "나")
+        `when`(userRepository.findById(1L)).thenReturn(me)
+        `when`(coupleRepository.findByUserId(1L)).thenReturn(null)
+
+        val result = myPageService.getMyPage(1L)
+
+        assertNull(result.coupledDay)
+        assertNull(result.partnerName)
     }
 }

--- a/src/test/kotlin/kr/co/lokit/api/domain/user/application/MyPageServiceTest.kt
+++ b/src/test/kotlin/kr/co/lokit/api/domain/user/application/MyPageServiceTest.kt
@@ -96,6 +96,7 @@ class MyPageServiceTest {
         val result = myPageService.getMyPage(1L)
 
         assertEquals("test@test.com", result.myEmail)
+        assertEquals(LocalDate.now().minusDays(9), result.firstMetDate)
         assertEquals(10L, result.coupledDay)
     }
 
@@ -116,6 +117,7 @@ class MyPageServiceTest {
 
         val result = myPageService.getMyPage(1L)
 
+        assertNull(result.firstMetDate)
         assertNull(result.coupledDay)
     }
 
@@ -127,6 +129,7 @@ class MyPageServiceTest {
 
         val result = myPageService.getMyPage(1L)
 
+        assertNull(result.firstMetDate)
         assertNull(result.coupledDay)
         assertNull(result.partnerName)
     }

--- a/src/test/kotlin/kr/co/lokit/api/domain/user/application/MyPageServiceTest.kt
+++ b/src/test/kotlin/kr/co/lokit/api/domain/user/application/MyPageServiceTest.kt
@@ -95,6 +95,7 @@ class MyPageServiceTest {
 
         val result = myPageService.getMyPage(1L)
 
+        assertEquals("test@test.com", result.myEmail)
         assertEquals(10L, result.coupledDay)
     }
 
@@ -128,5 +129,16 @@ class MyPageServiceTest {
 
         assertNull(result.coupledDay)
         assertNull(result.partnerName)
+    }
+
+    @Test
+    fun `마이페이지 조회 시 내 이메일이 포함된다`() {
+        val me = createUser(id = 1L, name = "나", email = "myemail@test.com")
+        `when`(userRepository.findById(1L)).thenReturn(me)
+        `when`(coupleRepository.findByUserId(1L)).thenReturn(null)
+
+        val result = myPageService.getMyPage(1L)
+
+        assertEquals("myemail@test.com", result.myEmail)
     }
 }

--- a/src/test/kotlin/kr/co/lokit/api/domain/user/application/UserWithdrawServiceTest.kt
+++ b/src/test/kotlin/kr/co/lokit/api/domain/user/application/UserWithdrawServiceTest.kt
@@ -95,12 +95,24 @@ class UserWithdrawServiceTest {
     @Test
     fun `연결 끊기가 완료되지 않은 상태에서는 탈퇴할 수 없다`() {
         val user = createUser(id = 1L, email = "test@test.com")
-        val couple = createCouple(id = 10L, userIds = listOf(1L), status = kr.co.lokit.api.common.constants.CoupleStatus.CONNECTED)
+        val couple = createCouple(id = 10L, userIds = listOf(1L, 2L), status = kr.co.lokit.api.common.constants.CoupleStatus.CONNECTED)
         whenever(userRepository.findById(1L)).thenReturn(user)
         whenever(coupleRepository.findByUserId(1L)).thenReturn(couple)
 
         assertThrows<BusinessException.UserDisconnectRequiredException> {
             userWithdrawService.withdraw(1L)
         }
+    }
+
+    @Test
+    fun `커플이 DISCONNECTED 상태이면 탈퇴할 수 있다`() {
+        val user = createUser(id = 1L, email = "test@test.com")
+        val couple = createCouple(id = 10L, userIds = listOf(1L), status = kr.co.lokit.api.common.constants.CoupleStatus.DISCONNECTED)
+        whenever(userRepository.findById(1L)).thenReturn(user)
+        whenever(coupleRepository.findByUserId(1L)).thenReturn(couple)
+
+        userWithdrawService.withdraw(1L)
+
+        verify(userRepository).withdraw(1L)
     }
 }

--- a/src/test/kotlin/kr/co/lokit/api/fixture/DomainFixtures.kt
+++ b/src/test/kotlin/kr/co/lokit/api/fixture/DomainFixtures.kt
@@ -47,7 +47,8 @@ fun createCouple(
     status: CoupleStatus = CoupleStatus.CONNECTED,
     disconnectedAt: LocalDateTime? = null,
     disconnectedByUserId: Long? = null,
-) = Couple(id = id, name = name, userIds = userIds, status = status, disconnectedAt = disconnectedAt, disconnectedByUserId = disconnectedByUserId)
+    firstMetDate: LocalDate? = null,
+) = Couple(id = id, name = name, userIds = userIds, status = status, disconnectedAt = disconnectedAt, disconnectedByUserId = disconnectedByUserId, firstMetDate = firstMetDate)
 
 fun createAlbum(
     id: Long = 0L,

--- a/src/test/kotlin/kr/co/lokit/api/fixture/RequestFixtures.kt
+++ b/src/test/kotlin/kr/co/lokit/api/fixture/RequestFixtures.kt
@@ -6,8 +6,10 @@ import kr.co.lokit.api.domain.couple.dto.JoinCoupleRequest
 import kr.co.lokit.api.domain.photo.dto.CreatePhotoRequest
 import kr.co.lokit.api.domain.photo.dto.PresignedUrlRequest
 import kr.co.lokit.api.domain.photo.dto.UpdatePhotoRequest
+import kr.co.lokit.api.domain.couple.dto.UpdateFirstMetDateRequest
 import kr.co.lokit.api.domain.user.dto.UpdateNicknameRequest
 import kr.co.lokit.api.domain.user.dto.UpdateProfileImageRequest
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 fun createAlbumRequest(
@@ -62,3 +64,7 @@ fun createUpdateNicknameRequest(
 fun createUpdateProfileImageRequest(
     profileImageUrl: String = "https://example.com/profile.jpg",
 ) = UpdateProfileImageRequest(profileImageUrl = profileImageUrl)
+
+fun createUpdateFirstMetDateRequest(
+    firstMetDate: LocalDate = LocalDate.of(2024, 1, 1),
+) = UpdateFirstMetDateRequest(firstMetDate = firstMetDate)


### PR DESCRIPTION
## 수정 이유
기능 요구사항

## 추가/수정한 기능
로그아웃, 커플 만남 수정 가능하도록 구현

## 특이사항
x
## check list

- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 커플의 "처음 만난 날짜" 기록 및 수정 기능(엔드포인트 추가)
  * 로그아웃 시 세션/토큰 삭제 및 관련 쿠키 초기화 기능 추가
  * 마이페이지에 사용자 이메일과 처음 만난 날짜 및 D-Day 표시 추가
  * 커플 초대/복구 처리 개선

* **Tests**
  * 처음 만난 날짜 관련 단위·컨트롤러 테스트 추가
  * 로그아웃 흐름 테스트 추가
  * 마이페이지 관련 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->